### PR TITLE
[fix] add range to address verification to match variable length

### DIFF
--- a/assembly/__tests__/vm-mock.spec.ts
+++ b/assembly/__tests__/vm-mock.spec.ts
@@ -16,7 +16,7 @@ const testAddress = new Address(
   'AU12E6N5BFAdC2wyiBV6VJjqkWhpz1kLVp2XpbRdSnL1mKjCWT6oR',
 );
 const badAddress = new Address(
-  'AUé2E6N5BFAdC2wyiBV6VJjqkWhpz1kLVp2XpbRdSnL1mKjCWT6oR',
+  'ALé2E6N5BFAdC2wyiBV6VJjqkWhpz1kLVp2XpbRdSnL1mKjCWT6oR',
 );
 
 const testAddress2 = new Address(

--- a/vm-mock/vm.js
+++ b/vm-mock/vm.js
@@ -414,11 +414,20 @@ export default function createMockedABI(
 
       assembly_script_validate_address(addressPtr) {
         const address = ptrToString(addressPtr);
+        const prefix = 'A';
+        const userOrSC = ['U', 'S'];
+        const minLength = 40;
+        const maxLength = 60;
 
-        return (
-          stringToByteArray(address).length === addressBytesLength &&
-          (address.startsWith('AU') || address.startsWith('AS'))
-        );
+        if (address.length < minLength && address.length > maxLength) {
+          return false;
+        }
+
+        if (address.startsWith(prefix) && userOrSC.includes(address[1])) {
+          return true;
+        }
+
+        return false;
       },
 
       assembly_script_print(aPtr) {

--- a/vm-mock/vm.js
+++ b/vm-mock/vm.js
@@ -7,7 +7,6 @@ const { createHash } = await import('node:crypto');
 // Those both addresses have been randomly generated
 const callerAddress = 'AU12UBnqTHDQALpocVBnkPNy7y5CndUJQTLutaVDDFgMJcq5kQiKq';
 const contractAddress = 'AS12BqZEQ6sByhRLyEuf0YbQmcF2PsDdkNNG1akBJu9XcjZA1eT';
-const addressBytesLength = 53;
 
 /**
  * return a random string
@@ -188,6 +187,37 @@ export default function createMockedABI(
     }
 
     return new Uint8Array(serialized);
+  }
+
+  /**
+   * Check if the address prefix is valid
+   *
+   * @param {string} address
+   *
+   * @returns {boolean}
+   */
+  function isRightPrefix(address) {
+    const addressPrefix = 'A';
+    const addressPrefixUserOrSC = ['U', 'S'];
+    return (
+      address.startsWith(addressPrefix) &&
+      addressPrefixUserOrSC.includes(address[1])
+    );
+  }
+
+  /**
+   * Check if the address length is valid
+   *
+   * @param {string} address
+   *
+   * @returns {boolean}
+   */
+  function isRightLength(address) {
+    const minAddressLength = 40;
+    const maxAddressLength = 60;
+    return (
+      address.length >= minAddressLength && address.length <= maxAddressLength
+    );
   }
 
   resetLedger();
@@ -414,20 +444,8 @@ export default function createMockedABI(
 
       assembly_script_validate_address(addressPtr) {
         const address = ptrToString(addressPtr);
-        const prefix = 'A';
-        const userOrSC = ['U', 'S'];
-        const minLength = 40;
-        const maxLength = 60;
 
-        if (address.length < minLength && address.length > maxLength) {
-          return false;
-        }
-
-        if (address.startsWith(prefix) && userOrSC.includes(address[1])) {
-          return true;
-        }
-
-        return false;
+        return isRightLength(address) && isRightPrefix(address);
       },
 
       assembly_script_print(aPtr) {


### PR DESCRIPTION
This is a temporary fix. The reason is address can have different length so it's better for now to have a range. It will be completely fixed with : https://github.com/massalabs/massa-as-sdk/issues/229#issuecomment-1510793590