### PR TITLE
[archi] move fileToByteArray in contract

### DIFF
--- a/assembly/std/contract/fileToByteArray.ts
+++ b/assembly/std/contract/fileToByteArray.ts
@@ -2,7 +2,7 @@
  * Convert the given file content to byteArray.
  *
  * @remarks
- * This function is dynamically replaced using the byteArray converter.
+ * This function is dynamically replaced using the byteArray converter during the compilation.
  * @see [as-transformer](https://github.com/massalabs/as/tree/main/packages/as-transformer#file2bytearray)
  *
  * @param filePath - the file path to convert

--- a/assembly/std/contract/index.ts
+++ b/assembly/std/contract/index.ts
@@ -24,8 +24,13 @@
  * - {@link getBytecodeOf}.
  * - {@link createSC}.
  *
+ * In the file **fileToByteArray.ts** you can find a function that convert a **smart-contract file** to a **byteArray**:
+ * - {@link fileToByteArray}.
+ *
+ *
  * @module
  *
  */
 export * from './calls';
 export * from './bytecode';
+export * from './fileToByteArray';

--- a/assembly/std/utils/index.ts
+++ b/assembly/std/utils/index.ts
@@ -37,9 +37,6 @@
  * In the file **random.ts** you can find functions to generate **random numbers** such as:
  * - {@link unsafeRandom}.
  *
- * In the file **file-utils.ts** you can find functions to manipulate **files** such as:
- * - {@link fileToByteArray}.
- *
  * @module
  *
  */
@@ -50,4 +47,3 @@ export * from './crypto';
 export * from './events';
 export * from './logging';
 export * from './random';
-export * from './file-utils';


### PR DESCRIPTION
I chose to move fileToByteArray in it's own file into contract folder because it's very specific